### PR TITLE
Response DTO's moved to more accurate namespace

### DIFF
--- a/src/Rpc/Responses/DTOs/GetBalanceDTO.php
+++ b/src/Rpc/Responses/DTOs/GetBalanceDTO.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace JadNetwork\LaravelSolana\Rpc\Requests\DTOs;
+namespace JadNetwork\LaravelSolana\Rpc\Responses\DTOs;
 
 use Illuminate\Support\Carbon;
 

--- a/src/Rpc/Responses/DTOs/GetTokenAccountBalanceDTO.php
+++ b/src/Rpc/Responses/DTOs/GetTokenAccountBalanceDTO.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace JadNetwork\LaravelSolana\Rpc\Requests\DTOs;
+namespace JadNetwork\LaravelSolana\Rpc\Responses\DTOs;
 
 use Illuminate\Support\Carbon;
 

--- a/src/Rpc/Responses/GetBalanceResponse.php
+++ b/src/Rpc/Responses/GetBalanceResponse.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace JadNetwork\LaravelSolana\Rpc\Responses;
 
-use JadNetwork\LaravelSolana\Rpc\Requests\DTOs\GetBalanceDTO;
+use JadNetwork\LaravelSolana\Rpc\Responses\DTOs\GetBalanceDTO;
 
 class GetBalanceResponse extends RpcBaseResponse
 {


### PR DESCRIPTION
Moved to correct namespace for improved project structure.

Previously ResponseDTO's were incorrectly located in the Requests namespace.