### PR TITLE
Removed Laravel10 and PHP8.4 from Test Action

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,16 +16,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        php: [8.4, 8.3]
-        laravel: [11.*, 10.*]
-        stability: [prefer-lowest, prefer-stable]
+        os: [ ubuntu-latest ]
+        php: [ 8.3 ]
+        laravel: [ 11.* ]
+        stability: [ prefer-lowest, prefer-stable ]
         include:
           - laravel: 11.*
             testbench: 9.*
-            carbon: ^2.63
-          - laravel: 10.*
-            testbench: 8.*
             carbon: ^2.63
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}


### PR DESCRIPTION
There are no plans for laravel 10 support until we have finished a working project on Laravel 11.

PHP CS Fixer & Pint have issues with PHP8.4 currently so I've temporarily set testing for PHP8.3 only.
